### PR TITLE
Fix the asynchronous worker timeout issue.

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -111,6 +111,7 @@ from .utils import (
 
 from clickhouse_driver import Client
 import os
+from time import sleep
 
 config = app.config
 CACHE_DEFAULT_TIMEOUT = config.get("CACHE_DEFAULT_TIMEOUT", 0)
@@ -2798,6 +2799,9 @@ class Superset(BaseSupersetView):
         def generate():
             cnt = 0
             for row in rows_gen:
+                # We add sleep(0) between generator iterations to give the worker a break 
+                # to update the heartbeat file and keep the connection and worker process alive.
+                sleep(0)
                 s = ''
                 for item in row:
                     item = str(item).replace('\n', '')


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Workers silent for more than this many seconds are killed and restarted. By silent, it means silent from the perspective of the arbiter process, which communicates with the workers through a temporary file. If the worker is busy sending data, it does not update that file. From the perspective of the arbiter, the worker is missing heartbeats.

We add sleep(0) between generator iterations to give the worker a break and update the heartbeat file to keep the connection and worker process alive.